### PR TITLE
feat: @ModelAttribute를 활용한 상품 등록 처리 개선

### DIFF
--- a/src/main/java/hello/itemservice/web/basic/BasicItemController.java
+++ b/src/main/java/hello/itemservice/web/basic/BasicItemController.java
@@ -6,9 +6,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -36,6 +34,48 @@ public class BasicItemController {
     public String addForm() {
         return "basic/addForm";
     }
+
+//    @PostMapping("/add")
+    public String addItemV1(@RequestParam("itemName") String itemName,
+                            @RequestParam("price") int price,
+                            @RequestParam("quantity") Integer quantity,
+                            Model model) {
+        Item item = new Item();
+        item.setItemName(itemName);
+        item.setPrice(price);
+        item.setQuantity(quantity);
+        itemRepository.save(item);
+        model.addAttribute("item", item);
+        return "basic/item";
+    }
+
+//    @PostMapping("/add")
+    public String addItemV2(@ModelAttribute("item") Item item, Model model) {
+
+        itemRepository.save(item);
+        model.addAttribute("item", item);
+
+        return "basic/item";
+    }
+
+//    @PostMapping("/add")
+    public String addItemV3(@ModelAttribute Item item, Model model) {
+
+        itemRepository.save(item);
+        model.addAttribute("item", item);
+
+        return "basic/item";
+    }
+
+    @PostMapping("/add")
+    public String addItemV4(Item item) {
+
+        itemRepository.save(item);
+
+        return "basic/item";
+    }
+
+
     /**
      * 테스트 데이터
      */

--- a/src/main/resources/templates/basic/items.html
+++ b/src/main/resources/templates/basic/items.html
@@ -14,7 +14,7 @@
         <div class="col">
             <button class="btn btn-primary float-end"
                     onclick="location.href='addForm.html'"
-                    th:onclick="|location.href='@{basic/items/add}'|"
+                    th:onclick="|location.href='@{/basic/items/add}'|"
                     type="button">상품 등록
             </button>
         </div>


### PR DESCRIPTION
### 변경 내용
- 상품 등록 시 @ModelAttribute를 활용하여 요청 파라미터 바인딩 및 모델 등록 처리
- addItemV2: @ModelAttribute 명시, 모델 속성명 직접 지정
- addItemV3: @ModelAttribute 이름 생략
- addItemV4: @ModelAttribute 자체 생략

### 참고 사항
- 기존 addItemV1은 주석 처리하여 중복 매핑 방지
- @ModelAttribute의 이름을 생략하면, 스프링은 바인딩 대상 객체의 클래스명을 기반으로 모델에 저장할 이름을 자동으로 생성(첫 글자만 소문자)